### PR TITLE
Disable methods, as this represent Data Types + less strict primitives check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 ![GitHub package.json version](https://img.shields.io/github/package-json/v/wentout/typeomatica)
 ![GitHub last commit](https://img.shields.io/github/last-commit/wentout/typeomatica)
 
-[![NPM](https://nodei.co/npm/typeomatica.png?mini=true)](https://www.npmjs.com/package/typeomatica)
+[**$ npm install <u>typeomatica</u>**](https://www.npmjs.com/package/typeomatica)
 
 
-this package is a part of [mnemonica](https://www.npmjs.com/package/mnemonica) project
+This package is a part of [mnemonica](https://www.npmjs.com/package/mnemonica) project.
 
-simple strong type restriction for mnemonica based types
+Strict Types checker for objects which represent Data Types.
 
 # how it works
 
@@ -23,11 +23,22 @@ class SimpleBase extends BasePrototype {
 	stringProp = '123';
 };
 
-// next code line will throw TypeError('Type Mismatch')
+// nect code line will work properly
+simpleInstance.stringProp = '321';
+
+// but next code line will throw TypeError('Type Mismatch')
 // @ts-ignore
 simpleInstance.stringProp = 123;
 
-
 ```
 
-That is it, it will be impossible to assign anything else except of string to `stringProp` in runtime.
+That is it. It will be impossible to assign anything else except of:
+
+```js 
+typeof something === 'string'
+```
+
+to `stringProp` in runtime.
+
+As we describe Data Types &mdash; please take a peek for tests directory:
+[HERE](https://github.com/wentout/typeomatica/blob/main/test/index.ts).

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,13 +17,17 @@ const isPrimitive = (value) => {
 };
 const primitives = (initialValue) => {
     let value = Object(initialValue);
+    const initialType = typeof initialValue;
     return {
         get() {
             const proxyAsValue = new Proxy(value, {
                 get(_, prop) {
                     if (prop === Symbol.toPrimitive) {
-                        return function () {
-                            throw new ReferenceError(ErrorsNames.ACCESS_DENIED);
+                        return function (hint) {
+                            if (hint !== initialType) {
+                                throw new ReferenceError(ErrorsNames.ACCESS_DENIED);
+                            }
+                            return value.valueOf();
                         };
                     }
                     if (prop === 'valueOf') {
@@ -41,7 +45,12 @@ const primitives = (initialValue) => {
         },
         set(replacementValue) {
             if (replacementValue instanceof value.constructor) {
-                value = Object(replacementValue);
+                value = replacementValue;
+                return value;
+            }
+            const prevalue = Object(replacementValue);
+            if (prevalue instanceof value.constructor) {
+                value = prevalue;
                 return value;
             }
             const error = new TypeError(ErrorsNames.TYPE_MISMATCH);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typeomatica",
-	"version": "0.1.1",
+	"version": "0.1.5",
 	"description": "type logic against javascript metaprogramming",
 	"main": "lib/index.js",
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ const isPrimitive = (value: unknown) => {
 
 const primitives = (initialValue: object) => {
 	let value = Object(initialValue);
+	const initialType = typeof initialValue;
 
 	return {
 		get() {
@@ -27,8 +28,11 @@ const primitives = (initialValue: object) => {
 				get(_, prop) {
 
 					if (prop === Symbol.toPrimitive) {
-						return function () {
-							throw new ReferenceError(ErrorsNames.ACCESS_DENIED);
+						return function (hint: string) {
+							if (hint !== initialType) {
+								throw new ReferenceError(ErrorsNames.ACCESS_DENIED);
+							}
+							return value.valueOf();
 						}
 					}
 
@@ -62,9 +66,17 @@ const primitives = (initialValue: object) => {
 		// },
 		set(replacementValue: unknown) {
 			if (replacementValue instanceof value.constructor) {
-				value = Object(replacementValue);
+				value = replacementValue;
 				return value;
 			}
+
+			const prevalue = Object(replacementValue);
+
+			if (prevalue instanceof value.constructor) {
+				value = prevalue;
+				return value;
+			}
+
 			const error = new TypeError(ErrorsNames.TYPE_MISMATCH);
 			throw error;
 		}

--- a/test/index.ts
+++ b/test/index.ts
@@ -32,6 +32,8 @@ class SimpleBase extends BaseClass {
 
 const simpleInstance = new SimpleBase;
 
+const MUTATION_VALUE = -2;
+
 describe('props tests', () => {
 
 	test('simple instance works & strings too', () => {
@@ -106,13 +108,22 @@ describe('props tests', () => {
 
 	test('correct number arithmetics using .valueOf()', () => {
 
+		baseInstance.numberValue = MUTATION_VALUE;
+
 		const result = baseInstance.numberValue.valueOf() + 5;
-		expect(result).toEqual(128);
+		expect(result).toStrictEqual(3);
+
+	});
+
+	test('correct number arithmetics using hinting for Symbol.toPrimitive (hint)', () => {
+
+		const result = 3 + +baseInstance.numberValue;
+		expect(result).toStrictEqual(1);
 
 	});
 
 	test('correct number value', () => {
-		expect(baseInstance.numberValue.toString()).toBe('123');
+		expect(baseInstance.numberValue.toString()).toStrictEqual(MUTATION_VALUE.toString());
 		expect(/Number$/.test(baseInstance.numberValue.constructor.name)).toBe(true);
 	});
 
@@ -198,7 +209,7 @@ describe('props tests', () => {
 
 });
 
-describe('mutations tests', () => {
+describe('prototype mutations tests', () => {
 
 	test('incorrect prototype invocation number get', () => {
 		expect(() => {
@@ -250,7 +261,7 @@ describe('methods tests', () => {
 	test('proxy proto methods are SOLID', () => {
 
 		const result = baseInstance.someMethod();
-		expect(result).toBe(123);
+		expect(result).toBe(MUTATION_VALUE);
 
 	});
 


### PR DESCRIPTION
1. disable methods, as this represent Data Types
2. SOLID: allow functions for proxy prototypes
3. less strict checks for primitives